### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Utilities.TimeZones.nuspec
+++ b/MakoIoT.Device.Utilities.TimeZones.nuspec
@@ -17,9 +17,9 @@
     <description>Time zones and local time support for .NET nanoFramework C# projects.</description>
     <tags>nanoFramework C# csharp netmf netnf timezone</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.18" />
-      <dependency id="nanoFramework.System.Text" version="1.2.37" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.31" />
+      <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.15" />
     </dependencies>
   </metadata>

--- a/Tests/MakoIoT.Device.Utilities.TimeZones.Test/MakoIoT.Device.Utilities.TimeZones.Test.nfproj
+++ b/Tests/MakoIoT.Device.Utilities.TimeZones.Test/MakoIoT.Device.Utilities.TimeZones.Test.nfproj
@@ -36,23 +36,29 @@
     <ProjectReference Include="..\..\src\MakoIoT.Device.Utilities.TimeZones\MakoIoT.Device.Utilities.TimeZones.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.TestFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.UnitTestLauncher">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+    <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.52\lib\System.IO.Streams.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Utilities.TimeZones.Test/packages.config
+++ b/Tests/MakoIoT.Device.Utilities.TimeZones.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.85" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.52" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Utilities.TimeZones/MakoIoT.Device.Utilities.TimeZones.nfproj
+++ b/src/MakoIoT.Device.Utilities.TimeZones/MakoIoT.Device.Utilities.TimeZones.nfproj
@@ -27,17 +27,21 @@
     <Compile Include="TimeZoneConverter.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Text.RegularExpressions">
-      <HintPath>..\..\packages\nanoFramework.System.Text.RegularExpressions.1.1.37\lib\System.Text.RegularExpressions.dll</HintPath>
+    <Reference Include="System.Text.RegularExpressions, Version=1.1.51.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\nanoFramework.System.Text.RegularExpressions.1.1.51\lib\System.Text.RegularExpressions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Utilities.TimeZones/packages.config
+++ b/src/MakoIoT.Device.Utilities.TimeZones/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text.RegularExpressions" version="1.1.37" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text.RegularExpressions" version="1.1.51" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.15.5</br>Bumps nanoFramework.System.Collections from 1.5.18 to 1.5.31</br>Bumps nanoFramework.System.Text from 1.2.37 to 1.2.54</br>Bumps nanoFramework.System.Text.RegularExpressions from 1.1.37 to 1.1.51</br>Bumps nanoFramework.System.IO.Streams from 1.1.38 to 1.1.52</br>Bumps nanoFramework.TestFramework from 2.1.85 to 2.1.87</br>
[version update]

### :warning: This is an automated update. :warning:
