### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/Tests/MakoIoT.Device.Utilities.TimeZones.Test/MakoIoT.Device.Utilities.TimeZones.Test.nfproj
+++ b/Tests/MakoIoT.Device.Utilities.TimeZones.Test/MakoIoT.Device.Utilities.TimeZones.Test.nfproj
@@ -41,8 +41,8 @@
     <Reference Include="mscorlib">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Json">
-      <HintPath>..\..\packages\nanoFramework.Json.2.2.171\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.176.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Json.2.2.176\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.System.Collections">
       <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
@@ -50,14 +50,14 @@
     <Reference Include="nanoFramework.System.Text">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.60\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.67\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.UnitTestLauncher">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.60\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+    <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.67\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.82\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.86.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.86\lib\System.IO.Streams.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Utilities.TimeZones.Test/packages.config
+++ b/Tests/MakoIoT.Device.Utilities.TimeZones.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.171" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.176" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.82" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.86" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.60" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.67" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.Json from 2.2.171 to 2.2.176</br>Bumps nanoFramework.System.IO.Streams from 1.1.82 to 1.1.86</br>Bumps nanoFramework.TestFramework from 3.0.60 to 3.0.67</br>
[version update]

### :warning: This is an automated update. :warning:
